### PR TITLE
Cast object types to strings in dataframe formatter

### DIFF
--- a/src/variable_explorer/test.py
+++ b/src/variable_explorer/test.py
@@ -164,6 +164,9 @@ class TestDataframeDescribe(unittest.TestCase):
         self.assertTrue(type(result1['rows_top'][0]['col3']) is str)
         self.assertTrue(type(result1['rows_top'][1]['col2']) is str)
         self.assertTrue(type(result1['rows_top'][1]['col3']) is str)
+        self.assertEqual(result1['columns'][0]["dtype"], "int64")
+        self.assertEqual(result1['columns'][1]["dtype"], "object")
+        self.assertEqual(result1['columns'][1]["dtype"], "object")
 
 
 # # TODO: This is a semi-complete list of all the possible types that the user

--- a/src/variable_explorer/test.py
+++ b/src/variable_explorer/test.py
@@ -153,6 +153,18 @@ class TestDataframeDescribe(unittest.TestCase):
         self.assertEqual(result2['row_count'], 2)
         self.assertEqual(result2['column_count'], 3)
 
+    def test_object_to_string_casting(self):
+        df1 = pd.DataFrame(data={
+            'col1': [1,2],
+            'col2': [datetime.date(2000,1,1), datetime.time(10,30)],
+            'col3': [datetime.datetime.now().astimezone(pytz.timezone('UTC')), datetime.datetime.now().astimezone(None)]
+        })
+        result1 = describe_pd_dataframe(df1)
+        self.assertTrue(type(result1['rows_top'][0]['col2']) is str)
+        self.assertTrue(type(result1['rows_top'][0]['col3']) is str)
+        self.assertTrue(type(result1['rows_top'][1]['col2']) is str)
+        self.assertTrue(type(result1['rows_top'][1]['col3']) is str)
+
 
 # # TODO: This is a semi-complete list of all the possible types that the user
 # # might encounter. We want to make sure that all these types work (aka don't

--- a/src/variable_explorer/variable_explorer.py
+++ b/src/variable_explorer/variable_explorer.py
@@ -123,6 +123,7 @@ def _deepnote_add_formatters():
             return { MIME_TYPE: describe_pd_dataframe(df) }
         except:
             return { MIME_TYPE: { 'error': traceback.format_exc() } }
+
     get_ipython().display_formatter.mimebundle_formatter.for_type(pd.DataFrame, dataframe_formatter)
 
 if __name__ == '__main__':

--- a/src/variable_explorer/variable_explorer_helpers.py
+++ b/src/variable_explorer/variable_explorer_helpers.py
@@ -56,6 +56,13 @@ def get_categories(np_array):
 
     return [{"name": name, "count": count} for name, count in categories]
 
+# Cast potentially non json-serializable objects to strings to avoid ValueErrors during iPython json serialization
+def cast_objects_to_string(df):
+    for column in df:
+        # List of types: object, int64, float64, bool, datetime64m timedelta[ns], category (https://pbpython.com/pandas_dtypes.html)
+        if df[column].dtype == 'object':
+            df[column] = df[column].apply(str)
+    return df
 
 # TODO: Get rid of the dependency on unique column names (will require a change in format and not to use .to_dict())
 # TODO: Then remove the df.copy() to save memory.
@@ -100,14 +107,14 @@ def describe_pd_dataframe(df):
     if (len(df_analyzed) == max_rows_to_display):
         skip_start = None
         skip_end = None
-        df_display_top = df_analyzed.fillna('nan').to_dict(orient='records')
+        df_display_top = cast_objects_to_string(df_analyzed.fillna('nan')).to_dict(orient='records')
         df_display_bottom = None
     else:
         skip_count = len(df_analyzed) - max_rows_to_display
         skip_start = math.floor((len(df_analyzed) - skip_count) / 2)
         skip_end = skip_start + skip_count
-        df_display_top = df_analyzed.iloc[:skip_start].fillna('nan').to_dict(orient='records')
-        df_display_bottom = df_analyzed.iloc[skip_end:].fillna('nan').to_dict(orient='records')
+        df_display_top = cast_objects_to_string(df_analyzed.iloc[:skip_start].fillna('nan')).to_dict(orient='records')
+        df_display_bottom = cast_objects_to_string(df_analyzed.iloc[skip_end:].fillna('nan')).to_dict(orient='records')
 
     # Analyze columns
     columns = [{ 'name': name } for name in df_analyzed.columns]

--- a/src/variable_explorer/variable_explorer_helpers.py
+++ b/src/variable_explorer/variable_explorer_helpers.py
@@ -107,14 +107,14 @@ def describe_pd_dataframe(df):
     if (len(df_analyzed) == max_rows_to_display):
         skip_start = None
         skip_end = None
-        df_display_top = cast_objects_to_string(df_analyzed.fillna('nan')).to_dict(orient='records')
+        df_display_top = df_analyzed.fillna('nan')
         df_display_bottom = None
     else:
         skip_count = len(df_analyzed) - max_rows_to_display
         skip_start = math.floor((len(df_analyzed) - skip_count) / 2)
         skip_end = skip_start + skip_count
-        df_display_top = cast_objects_to_string(df_analyzed.iloc[:skip_start].fillna('nan')).to_dict(orient='records')
-        df_display_bottom = cast_objects_to_string(df_analyzed.iloc[skip_end:].fillna('nan')).to_dict(orient='records')
+        df_display_top = df_analyzed.iloc[:skip_start].fillna('nan')
+        df_display_bottom = df_analyzed.iloc[skip_end:].fillna('nan')
 
     # Analyze columns
     columns = [{ 'name': name } for name in df_analyzed.columns]
@@ -141,8 +141,8 @@ def describe_pd_dataframe(df):
         'row_count': len(df),
         'column_count': len(df.columns),
         'columns': columns,
-        'rows_top': df_display_top,
-        'rows_bottom': df_display_bottom,
+        'rows_top': cast_objects_to_string(df_display_top).to_dict(orient='records'),
+        'rows_bottom': None if df_display_bottom is None else cast_objects_to_string(df_display_bottom).to_dict(orient='records')
     }
 
 # TODO: Then remove the series.copy() to save memory.


### PR DESCRIPTION
This fixes https://community.deepnote.com/c/bugs/pandas-dataframes-with-datetimes-not-displaying#notifications

But I'm not exactly sure if I haven't broken something else by casting it. 

TODO: 
- [ ] try with BigQuery response (https://www.notion.so/deepnote/e4b491e701054f0ba4d4d641b219c29a?v=7b366a6fe5a44acf9e699b825f298de9&p=0f31d564cf8245c7ba9459bbc12ce04d)